### PR TITLE
fix(core): windows filename chars fix & file store directory fix

### DIFF
--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -40,8 +40,8 @@ type GlobalConfig struct {
 
 // LoadGlobalConfig loads the global configuration from the store for the given name of the configuration being stored.
 // (i.e. if storing a config for example_app, then the configName should be "example_app")
-func LoadGlobalConfig(configName string, newStore store.NewStoreInterface) (*GlobalStore, error) {
-	store, err := newStore(configName, STORE_KEY_GLOBAL)
+func LoadGlobalConfig(configName string, newStore store.NewStoreInterface, driverOpts ...store.DriverOpt) (*GlobalStore, error) {
+	store, err := newStore(configName, STORE_KEY_GLOBAL, driverOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/storeFileSystem.go
+++ b/pkg/store/storeFileSystem.go
@@ -51,9 +51,9 @@ func WithStoreDirectory(storeDir string) DriverOpt {
 
 // TODO: should we use this throughout all stores and add it to the interface?
 // URN-based namespace template without UUID, using only profile name for uniqueness
-// i.e. urn:goosprofiles:<serviceNamespace>:profile:<version>:<profileName>
+// i.e. urn.goosprofiles.<serviceNamespace>.profile.<version>.<profileName>
 func BuildNamespaceURN(serviceNamespace, version string) string {
-	return fmt.Sprintf("urn:goosprofiles:%s:profile:%s", serviceNamespace, version)
+	return fmt.Sprintf("urn.goosprofiles.%s.profile.%s", serviceNamespace, version)
 }
 
 // NewFileStore is the constructor function for fileStore, setting the file path based on executable directory or environment variable and hashed filename
@@ -97,7 +97,7 @@ var NewFileStore NewStoreInterface = func(serviceNamespace, key string, driverOp
 	}
 
 	urn := BuildNamespaceURN(serviceNamespace, version1)
-	fileName := fmt.Sprintf("%s_%s", urn, key)
+	fileName := fmt.Sprintf("%s.%s", urn, key)
 	filePath := filepath.Join(baseDir, fileName+".enc")
 	return &fileStore{
 		namespaceVersionURN: urn,

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -44,6 +44,26 @@ func Test_ValidateNamespaceKey(t *testing.T) {
 			ErrValueBadCharacters,
 		},
 		{
+			"name:",
+			"key",
+			ErrValueBadCharacters,
+		},
+		{
+			"name|",
+			"key",
+			ErrValueBadCharacters,
+		},
+		{
+			"name/",
+			"key",
+			ErrValueBadCharacters,
+		},
+		{
+			"name\\",
+			"key",
+			ErrValueBadCharacters,
+		},
+		{
 			"name",
 			"key@",
 			ErrValueBadCharacters,
@@ -139,7 +159,7 @@ func Test_NewFileSystemStore_DirectoryProvided(t *testing.T) {
 
 	// check the written files
 	foundGlobalConfigFile := false
-	foundSingleProfileFile := false
+	foundGlobalConfigEncFile := false
 	for _, file := range files {
 		path := filepath.Join(dir, file.Name())
 		data, err := os.ReadFile(path)
@@ -155,20 +175,20 @@ func Test_NewFileSystemStore_DirectoryProvided(t *testing.T) {
 		assert.True(t, isEncrypted)
 
 		// assert file name matches URN
-		split := strings.Split(file.Name(), ":")
+		split := strings.Split(file.Name(), ".")
 		assert.Equal(t, testNS, split[2])
 
-		last := split[len(split)-1]
+		last := file.Name()[len(testKey):]
 		if strings.Contains(last, testKey+".nfo") {
 			foundGlobalConfigFile = true
 		}
 		if strings.Contains(last, testKey+".enc") {
-			foundSingleProfileFile = true
+			foundGlobalConfigEncFile = true
 		}
 	}
 
 	assert.True(t, foundGlobalConfigFile)
-	assert.True(t, foundSingleProfileFile)
+	assert.True(t, foundGlobalConfigEncFile)
 
 	data, err := store.Get()
 	require.NoError(t, err)

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -213,7 +213,10 @@ func Test_NewKeyringStore(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, store)
 
-	require.False(t, store.Exists())
+	// dir should still be empty after store init
+	files, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Zero(t, len(files))
 
 	value := mockStoredValue{
 		Name:      "test_keyring",
@@ -224,7 +227,7 @@ func Test_NewKeyringStore(t *testing.T) {
 	require.True(t, store.Exists())
 
 	// ensure exactly zero files were written to the store driver directory
-	files, err := os.ReadDir(dir)
+	files, err = os.ReadDir(dir)
 	require.NoError(t, err)
 	require.Zero(t, len(files))
 

--- a/profile.go
+++ b/profile.go
@@ -99,7 +99,7 @@ func New(configName string, opts ...profileConfigVariadicFunc) (*Profiler, error
 	}
 
 	// Load global configuration
-	p.globalStore, err = global.LoadGlobalConfig(configName, newStore)
+	p.globalStore, err = global.LoadGlobalConfig(configName, newStore, config.driverOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/profile_test.go
+++ b/profile_test.go
@@ -1,6 +1,8 @@
 package profiles
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/jrschumacher/go-osprofiles/internal/global"
@@ -10,7 +12,11 @@ import (
 
 type ProfilesSuite struct {
 	suite.Suite
-	p *Profiler
+
+	keyringProfiler *Profiler
+
+	fileSystemProfiler *Profiler
+	testTempDir        string
 }
 
 type mockProfile struct {
@@ -27,21 +33,121 @@ func (p *mockProfile) GetName() string {
 
 const testConsumerServiceProfiler = "test-consumer-service-profiler"
 
-func (s *ProfilesSuite) SetupSuite() {
-	profiler, err := New(testConsumerServiceProfiler, WithKeyringStore())
-	s.Require().NoError(err)
-	s.Require().NotNil(profiler)
+// TODO: integration test profile lifecycle for in-memory
 
-	s.p = profiler
+func (s *ProfilesSuite) SetupSuite() {
+	keyringProfiler, err := New(testConsumerServiceProfiler, WithKeyringStore())
+	s.Require().NoError(err)
+	s.Require().NotNil(keyringProfiler)
+	s.keyringProfiler = keyringProfiler
+
+	// Set up a temporary profiles directory
+	tempDir := os.TempDir()
+	dirPath := filepath.Join(tempDir, "profiles")
+	err = os.MkdirAll(dirPath, os.ModePerm)
+	s.Require().NoError(err)
+	s.testTempDir = dirPath
+
+	fileSystemProfiler, err := New(testConsumerServiceProfiler, WithFileStore(s.testTempDir))
+	s.Require().NoError(err)
+	s.Require().NotNil(fileSystemProfiler)
+	s.fileSystemProfiler = fileSystemProfiler
 }
 
 func (s *ProfilesSuite) TearDownSuite() {
 	// Remove all keyring entries added by the test suite
 	//nolint:errcheck // teardown error not relevant
 	keyring.DeleteAll(testConsumerServiceProfiler)
+
+	// Remove all stored profiles set to the temp directory
+	//nolint:errcheck // teardown error not relevant
+	os.RemoveAll(s.testTempDir)
 }
 
-// TODO: integration test profile lifecycle for other store types
+func (s *ProfilesSuite) TestLifecycleProfile_FileStore() {
+	profile := &mockProfile{
+		Name:      "test-profile-fs",
+		TestValue: "test-value-fs",
+		Nested: struct {
+			SubValue int `json:"sub_value"`
+		}{1},
+	}
+	fileSystemProfiler := s.fileSystemProfiler
+
+	// no profiles
+	list := ListProfiles(fileSystemProfiler)
+	s.Require().Len(list, 0)
+
+	// add a test profile
+	s.Require().NoError(fileSystemProfiler.AddProfile(profile, true))
+
+	// ensure new profile created
+	list = ListProfiles(fileSystemProfiler)
+	s.Require().Len(list, 1)
+	s.Require().Equal(list[0], profile.Name)
+
+	// ensure profile exists
+	p, err := GetProfile[*mockProfile](fileSystemProfiler, profile.Name)
+	s.Require().NoError(err)
+	s.Require().NotNil(p)
+	s.Require().NotNil(p.Profile)
+	s.Require().Equal(profile.Name, p.Profile.GetName())
+	s.Require().Equal(profile.TestValue, p.Profile.(*mockProfile).TestValue)
+	s.Require().Equal(profile.Nested.SubValue, p.Profile.(*mockProfile).Nested.SubValue)
+
+	// check the file system
+	files, err := os.ReadDir(s.testTempDir)
+	s.Require().NoError(err)
+	s.Require().Len(files, 4)
+
+	// test conflict if creating same profile name twice
+	err = fileSystemProfiler.AddProfile(profile, true)
+	s.Require().ErrorIs(err, ErrProfileNameConflict)
+
+	// update it
+	profile.TestValue = "test-value-updated-123"
+	s.Require().NoError(UpdateCurrentProfile(fileSystemProfiler, profile))
+
+	// get it again
+	p, err = GetProfile[*mockProfile](fileSystemProfiler, profile.Name)
+	s.Require().NoError(err)
+	s.Require().NotNil(p)
+	s.Require().NotNil(p.Profile)
+	s.Require().Equal(profile.Name, p.Profile.GetName())
+	// updated successfully
+	s.Require().Equal(profile.TestValue, p.Profile.(*mockProfile).TestValue)
+
+	// delete fails due to being default
+	err = DeleteProfile[*mockProfile](fileSystemProfiler, profile.Name)
+	s.Require().ErrorIs(err, global.ErrDeletingDefaultProfile)
+
+	// add a second profile
+	profile2 := &mockProfile{
+		Name: "test-profile-2-abc",
+	}
+	s.Require().NoError(fileSystemProfiler.AddProfile(profile2, false))
+
+	// find both in the list
+	list = ListProfiles(fileSystemProfiler)
+	s.Require().Len(list, 2)
+	s.Require().Equal(list[0], profile.Name)
+	s.Require().Equal(list[1], profile2.Name)
+
+	// check the file system
+	files, err = os.ReadDir(s.testTempDir)
+	s.Require().NoError(err)
+	s.Require().Len(files, 6)
+
+	// set the second profile as default
+	s.Require().NoError(SetDefaultProfile(fileSystemProfiler, profile2.Name))
+	// delete the first profile
+	s.Require().NoError(DeleteProfile[*mockProfile](fileSystemProfiler, profile.Name))
+
+	// ensure the first profile is gone
+	list = ListProfiles(fileSystemProfiler)
+	s.Require().Len(list, 1)
+	s.Require().Equal(list[0], profile2.Name)
+}
 
 func (s *ProfilesSuite) TestLifecycleProfile_Keyring() {
 	profile := &mockProfile{
@@ -51,21 +157,22 @@ func (s *ProfilesSuite) TestLifecycleProfile_Keyring() {
 			SubValue int `json:"sub_value"`
 		}{1},
 	}
+	keyringProfiler := s.keyringProfiler
 
 	// no profiles
-	list := ListProfiles(s.p)
+	list := ListProfiles(keyringProfiler)
 	s.Require().Len(list, 0)
 
 	// add a test profile
-	s.Require().NoError(s.p.AddProfile(profile, true))
+	s.Require().NoError(keyringProfiler.AddProfile(profile, true))
 
 	// ensure new profile created
-	list = ListProfiles(s.p)
+	list = ListProfiles(keyringProfiler)
 	s.Require().Len(list, 1)
 	s.Require().Equal(list[0], profile.Name)
 
 	// ensure profile exists
-	p, err := GetProfile[*mockProfile](s.p, profile.Name)
+	p, err := GetProfile[*mockProfile](keyringProfiler, profile.Name)
 	s.Require().NoError(err)
 	s.Require().NotNil(p)
 	s.Require().NotNil(p.Profile)
@@ -74,15 +181,15 @@ func (s *ProfilesSuite) TestLifecycleProfile_Keyring() {
 	s.Require().Equal(profile.Nested.SubValue, p.Profile.(*mockProfile).Nested.SubValue)
 
 	// test conflict if creating same profile name twice
-	err = s.p.AddProfile(profile, true)
+	err = keyringProfiler.AddProfile(profile, true)
 	s.Require().ErrorIs(err, ErrProfileNameConflict)
 
 	// update it
 	profile.TestValue = "test-value-updated"
-	s.Require().NoError(UpdateCurrentProfile(s.p, profile))
+	s.Require().NoError(UpdateCurrentProfile(keyringProfiler, profile))
 
 	// get it again
-	p, err = GetProfile[*mockProfile](s.p, profile.Name)
+	p, err = GetProfile[*mockProfile](keyringProfiler, profile.Name)
 	s.Require().NoError(err)
 	s.Require().NotNil(p)
 	s.Require().NotNil(p.Profile)
@@ -91,28 +198,28 @@ func (s *ProfilesSuite) TestLifecycleProfile_Keyring() {
 	s.Require().Equal(profile.TestValue, p.Profile.(*mockProfile).TestValue)
 
 	// delete fails due to being default
-	err = DeleteProfile[*mockProfile](s.p, profile.Name)
+	err = DeleteProfile[*mockProfile](keyringProfiler, profile.Name)
 	s.Require().ErrorIs(err, global.ErrDeletingDefaultProfile)
 
 	// add a second profile
 	profile2 := &mockProfile{
 		Name: "test-profile-2",
 	}
-	s.Require().NoError(s.p.AddProfile(profile2, false))
+	s.Require().NoError(keyringProfiler.AddProfile(profile2, false))
 
 	// find both in the list
-	list = ListProfiles(s.p)
+	list = ListProfiles(keyringProfiler)
 	s.Require().Len(list, 2)
 	s.Require().Equal(list[0], profile.Name)
 	s.Require().Equal(list[1], profile2.Name)
 
 	// set the second profile as default
-	s.Require().NoError(SetDefaultProfile(s.p, profile2.Name))
+	s.Require().NoError(SetDefaultProfile(keyringProfiler, profile2.Name))
 	// delete the first profile
-	s.Require().NoError(DeleteProfile[*mockProfile](s.p, profile.Name))
+	s.Require().NoError(DeleteProfile[*mockProfile](keyringProfiler, profile.Name))
 
 	// ensure the first profile is gone
-	list = ListProfiles(s.p)
+	list = ListProfiles(keyringProfiler)
 	s.Require().Len(list, 1)
 	s.Require().Equal(list[0], profile2.Name)
 }


### PR DESCRIPTION
1. URN cannot contain `:` which is an invalid character in Windows filenames
2. OS file store directory was not being properly passed to driver (meaning always defaulted to creating `./profiles` alongside running binary
3. integration test for profiles with file store driver