### PR TITLE
feat(core): platform OS lib should support optional publisher in paths

### DIFF
--- a/pkg/platform/darwin.go
+++ b/pkg/platform/darwin.go
@@ -9,10 +9,16 @@ import (
 type PlatformDarwin struct {
 	username         string
 	serviceNamespace string
+	servicePublisher string
 	userHomeDir      string
 }
 
-func NewPlatformDarwin(serviceNamespace string) (*PlatformDarwin, error) {
+const (
+	darwinLibrary    = "Library"
+	darwinAppSupport = "Application Support"
+)
+
+func NewPlatformDarwin(servicePublisher, serviceNamespace string) (*PlatformDarwin, error) {
 	usr, err := user.Current()
 	if err != nil {
 		return nil, ErrGettingUserOS
@@ -23,7 +29,7 @@ func NewPlatformDarwin(serviceNamespace string) (*PlatformDarwin, error) {
 		return nil, ErrGettingUserOS
 	}
 
-	return &PlatformDarwin{usr.Username, serviceNamespace, usrHomeDir}, nil
+	return &PlatformDarwin{usr.Username, serviceNamespace, servicePublisher, usrHomeDir}, nil
 }
 
 // GetUsername returns the username for macOS.
@@ -37,25 +43,45 @@ func (p PlatformDarwin) UserHomeDir() string {
 }
 
 // UserAppDataDirectory returns the namespaced user-level data directory for macOS.
-// i.e. ~/Library/Application Support/<serviceNamespace>
+// ~/Library/Application Support/<servicePublisher>/<serviceNamespace>
+// ~/Library/Application Support/<serviceNamespace> (if no pubisher)
 func (p PlatformDarwin) UserAppDataDirectory() string {
-	return filepath.Join(p.userHomeDir, "Library", "Application Support", p.serviceNamespace)
+	path := filepath.Join(p.userHomeDir, darwinLibrary, darwinAppSupport)
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }
 
 // UserAppConfigDirectory returns the namespaced user-level config directory for macOS.
-// i.e. ~/Library/Application Support/<serviceNamespace>
+// ~/Library/Application Support/<servicePublisher>/<serviceNamespace>
+// ~/Library/Application Support/<serviceNamespace> (if no publisher)
 func (p PlatformDarwin) UserAppConfigDirectory() string {
-	return filepath.Join(p.userHomeDir, "Library", "Application Support", p.serviceNamespace)
+	path := filepath.Join(p.userHomeDir, darwinLibrary, darwinAppSupport)
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }
 
 // SystemAppDataDirectory returns the namespaced system-level data directory for macOS.
-// i.e. /Library/Application Support/<serviceNamespace>
+// /Library/Application Support/<servicePublisher>/<serviceNamespace>
+// /Library/Application Support/<serviceNamespace> (if no publisher)
 func (p PlatformDarwin) SystemAppDataDirectory() string {
-	return filepath.Join("/", "Library", "Application Support", p.serviceNamespace)
+	path := filepath.Join("/", darwinLibrary, darwinAppSupport)
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }
 
 // SystemAppConfigDirectory returns the namespaced system-level config directory for macOS.
-// i.e. /Library/Application Support/<serviceNamespace>
+// /Library/Application Support/<servicePublisher>/<serviceNamespace>
+// /Library/Application Support/<serviceNamespace> (if no publisher)
 func (p PlatformDarwin) SystemAppConfigDirectory() string {
-	return filepath.Join("/", "Library", "Application Support", p.serviceNamespace)
+	path := filepath.Join("/", darwinLibrary, darwinAppSupport)
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }

--- a/pkg/platform/linux.go
+++ b/pkg/platform/linux.go
@@ -9,10 +9,11 @@ import (
 type PlatformLinux struct {
 	username         string
 	serviceNamespace string
+	servicePublisher string
 	userHomeDir      string
 }
 
-func NewPlatformLinux(serviceNamespace string) (*PlatformLinux, error) {
+func NewPlatformLinux(servicePublisher, serviceNamespace string) (*PlatformLinux, error) {
 	usr, err := user.Current()
 	if err != nil {
 		return nil, ErrGettingUserOS
@@ -23,7 +24,7 @@ func NewPlatformLinux(serviceNamespace string) (*PlatformLinux, error) {
 		return nil, ErrGettingUserOS
 	}
 
-	return &PlatformLinux{usr.Username, serviceNamespace, usrHomeDir}, nil
+	return &PlatformLinux{usr.Username, serviceNamespace, servicePublisher, usrHomeDir}, nil
 }
 
 // GetUsername returns the username for the Linux OS.
@@ -37,25 +38,45 @@ func (p PlatformLinux) UserHomeDir() string {
 }
 
 // UserAppDataDirectory returns the data directory for Linux.
-// i.e. ~/.local/share/<serviceNamespace>
+// ~/.local/share/<servicePublisher>/<serviceNamespace>
+// ~/.local/share/<serviceNamespace> (if no publisher)
 func (p PlatformLinux) UserAppDataDirectory() string {
-	return filepath.Join(p.userHomeDir, ".local", "share", p.serviceNamespace)
+	path := filepath.Join(p.userHomeDir, ".local", "share")
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }
 
 // UserAppConfigDirectory returns the config directory for Linux.
-// i.e. ~/.config/<serviceNamespace>
+// ~/.config/<servicePublisher>/<serviceNamespace>
+// ~/.config/<serviceNamespace>
 func (p PlatformLinux) UserAppConfigDirectory() string {
-	return filepath.Join(p.userHomeDir, ".config", p.serviceNamespace)
+	path := filepath.Join(p.userHomeDir, ".config")
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }
 
 // SystemAppDataDirectory returns the system-level data directory for Linux.
-// i.e. /var/lib/<serviceNamespace>
+// /usr/local/<servicePublisher>/<serviceNamespace>
+// /usr/local/<serviceNamespace> (if no publisher)
 func (p PlatformLinux) SystemAppDataDirectory() string {
-	return filepath.Join("/", "var", "lib", p.serviceNamespace)
+	path := filepath.Join("/", "usr", "local")
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }
 
 // SystemAppConfigDirectory returns the system-level config directory for Linux.
-// i.e. /etc/<serviceNamespace>
+// /etc/<servicePublisher>/<serviceNamespace>
+// /etc/<serviceNamespace> (if no publisher)
 func (p PlatformLinux) SystemAppConfigDirectory() string {
-	return filepath.Join("/", "etc", p.serviceNamespace)
+	path := filepath.Join("/", "etc")
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -16,14 +16,14 @@ type Platform interface {
 }
 
 // NewPlatform creates a new platform object based on the current operating system
-func NewPlatform(serviceNamespace, GOOS string) (Platform, error) {
+func NewPlatform(servicePublisher, serviceNamespace, GOOS string) (Platform, error) {
 	switch GOOS {
 	case "linux":
-		return NewPlatformLinux(serviceNamespace)
+		return NewPlatformLinux(servicePublisher, serviceNamespace)
 	case "windows":
-		return NewPlatformWindows(serviceNamespace)
+		return NewPlatformWindows(servicePublisher, serviceNamespace)
 	case "darwin":
-		return NewPlatformDarwin(serviceNamespace)
+		return NewPlatformDarwin(servicePublisher, serviceNamespace)
 	default:
 		return nil, ErrGettingUserOS
 	}

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -8,9 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_PlatformMacOS(t *testing.T) {
+func Test_PlatformMacOS_NoPublisher(t *testing.T) {
 	fakeAppName := "test-macos-app"
-	plat, err := NewPlatform(fakeAppName, "darwin")
+	var publisher string
+	plat, err := NewPlatform(publisher, fakeAppName, "darwin")
 
 	require.NoError(t, err)
 	require.NotNil(t, plat)
@@ -22,27 +24,61 @@ func Test_PlatformMacOS(t *testing.T) {
 	// user scoped
 	configDir := darwin.UserAppConfigDirectory()
 	assert.True(t, strings.HasSuffix(configDir, fakeAppName))
-	assert.True(t, strings.Contains(configDir, "/Library/Application Support"))
+	assert.True(t, strings.Contains(configDir, fmt.Sprintf("/Library/Application Support/%s", fakeAppName)))
 	assert.False(t, strings.HasPrefix(configDir, "/Library/Application Support"))
 
 	dataDir := darwin.UserAppDataDirectory()
 	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
-	assert.True(t, strings.Contains(dataDir, "/Library/Application Support"))
+	assert.True(t, strings.Contains(dataDir, fmt.Sprintf("/Library/Application Support/%s", fakeAppName)))
 	assert.False(t, strings.HasPrefix(configDir, "/Library/Application Support"))
 
 	// system scoped
 	configDir = darwin.SystemAppConfigDirectory()
 	assert.True(t, strings.HasSuffix(configDir, fakeAppName))
-	assert.True(t, strings.HasPrefix(configDir, "/Library/Application Support"))
+	assert.Equal(t, fmt.Sprintf("/Library/Application Support/%s", fakeAppName), configDir)
 
 	dataDir = darwin.SystemAppDataDirectory()
 	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
-	assert.True(t, strings.HasPrefix(dataDir, "/Library/Application Support"))
+	assert.Equal(t, fmt.Sprintf("/Library/Application Support/%s", fakeAppName), dataDir)
 }
 
-func Test_PlatformLinux(t *testing.T) {
+func Test_PlatformMacOS_WithPublisher(t *testing.T) {
+	fakeAppName := "test-with-publisher-app"
+	fakePublisher := "test-publisher"
+	plat, err := NewPlatform(fakePublisher, fakeAppName, "darwin")
+
+	require.NoError(t, err)
+	require.NotNil(t, plat)
+
+	darwin, ok := plat.(*PlatformDarwin)
+	require.True(t, ok)
+	require.NotNil(t, darwin)
+
+	// user scoped
+	configDir := darwin.UserAppConfigDirectory()
+	assert.True(t, strings.HasSuffix(configDir, fakeAppName))
+	assert.True(t, strings.Contains(configDir, fmt.Sprintf("/Library/Application Support/%s/%s", fakePublisher, fakeAppName)))
+	assert.False(t, strings.HasPrefix(configDir, "/Library/Application Support"))
+
+	dataDir := darwin.UserAppDataDirectory()
+	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
+	assert.True(t, strings.Contains(dataDir, fmt.Sprintf("/Library/Application Support/%s/%s", fakePublisher, fakeAppName)))
+	assert.False(t, strings.HasPrefix(dataDir, "/Library/Application Support"))
+
+	// system scoped
+	configDir = darwin.SystemAppConfigDirectory()
+	assert.True(t, strings.HasSuffix(configDir, fakeAppName))
+	assert.Equal(t, fmt.Sprintf("/Library/Application Support/%s/%s", fakePublisher, fakeAppName), configDir)
+
+	dataDir = darwin.SystemAppDataDirectory()
+	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
+	assert.Equal(t, fmt.Sprintf("/Library/Application Support/%s/%s", fakePublisher, fakeAppName), dataDir)
+}
+
+func Test_PlatformLinux_NoPublisher(t *testing.T) {
 	fakeAppName := "test-linux-app"
-	plat, err := NewPlatform(fakeAppName, "linux")
+	var publisher string
+	plat, err := NewPlatform(publisher, fakeAppName, "linux")
 
 	require.NoError(t, err)
 	require.NotNil(t, plat)
@@ -61,17 +97,52 @@ func Test_PlatformLinux(t *testing.T) {
 	dataDir := linux.UserAppDataDirectory()
 	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
 	assert.True(t, strings.Contains(dataDir, "/.local/share"))
-	assert.False(t, strings.HasPrefix(dataDir, "/var/lib"))
+	assert.False(t, strings.HasPrefix(dataDir, "/usr/local"))
 	assert.False(t, strings.HasPrefix(dataDir, "/.local/share"))
 
 	// system scoped
 	configDir = linux.SystemAppConfigDirectory()
 	assert.True(t, strings.HasSuffix(configDir, fakeAppName))
-	assert.True(t, strings.HasPrefix(configDir, "/etc"))
+	assert.Equal(t, fmt.Sprintf("/etc/%s", fakeAppName), configDir)
 
 	dataDir = linux.SystemAppDataDirectory()
 	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
-	assert.True(t, strings.HasPrefix(dataDir, "/var/lib"))
+	assert.Equal(t, fmt.Sprintf("/usr/local/%s", fakeAppName), dataDir)
+}
+
+func Test_PlatformLinux_WithPublisher(t *testing.T) {
+	fakeAppName := "test-publisher-linux-app"
+	fakeAppPublisher := "test-publisher"
+	plat, err := NewPlatform(fakeAppPublisher, fakeAppName, "linux")
+
+	require.NoError(t, err)
+	require.NotNil(t, plat)
+
+	linux, ok := plat.(*PlatformLinux)
+	require.True(t, ok)
+	require.NotNil(t, linux)
+
+	// user scoped
+	configDir := linux.UserAppConfigDirectory()
+	assert.True(t, strings.HasSuffix(configDir, fakeAppName))
+	assert.True(t, strings.Contains(configDir, fmt.Sprintf("/.config/%s/%s", fakeAppPublisher, fakeAppName)))
+	assert.False(t, strings.HasPrefix(configDir, "/.config"))
+	assert.False(t, strings.HasPrefix(configDir, "/etc"))
+
+	dataDir := linux.UserAppDataDirectory()
+	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
+	assert.True(t, strings.Contains(dataDir, fmt.Sprintf("/.local/share/%s/%s", fakeAppPublisher, fakeAppName)))
+	assert.False(t, strings.HasPrefix(dataDir, "/usr/local"))
+	assert.False(t, strings.HasPrefix(dataDir, "/.local/share"))
+
+	// system scoped
+	configDir = linux.SystemAppConfigDirectory()
+	assert.True(t, strings.HasSuffix(configDir, fakeAppName))
+	assert.Equal(t, fmt.Sprintf("/etc/%s/%s", fakeAppPublisher, fakeAppName), configDir)
+
+	dataDir = linux.SystemAppDataDirectory()
+	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
+	assert.Equal(t, fmt.Sprintf("/usr/local/%s/%s", fakeAppPublisher, fakeAppName), dataDir)
 }
 
 // test utility to convert path to windows format and simplify cross-platform testing
@@ -79,7 +150,7 @@ func convertToWindowsPath(path string) string {
 	return strings.ReplaceAll(path, "/", `\`)
 }
 
-func Test_PlatformWindows(t *testing.T) {
+func Test_PlatformWindows_NoPublisher(t *testing.T) {
 	fakeDrive := "FakeCDrive:\\"
 	// set up fake environment variables
 	t.Setenv(envKeyLocalAppData, fakeDrive+"Users\\test\\AppData\\Local")
@@ -87,7 +158,8 @@ func Test_PlatformWindows(t *testing.T) {
 	t.Setenv(envKeyProgramFiles, fakeDrive+"ProgramFiles")
 
 	fakeAppName := "test-windows-app"
-	plat, err := NewPlatform(fakeAppName, "windows")
+	var publisher string
+	plat, err := NewPlatform(publisher, fakeAppName, "windows")
 
 	require.NoError(t, err)
 	require.NotNil(t, plat)
@@ -117,4 +189,47 @@ func Test_PlatformWindows(t *testing.T) {
 	dataDir = convertToWindowsPath(dataDir)
 	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
 	assert.True(t, strings.HasPrefix(dataDir, fakeDrive+"ProgramData\\"))
+}
+
+func Test_PlatformWindows_WithPublisher(t *testing.T) {
+	fakeDrive := "FakeCDrive:\\"
+	// set up fake environment variables
+	t.Setenv(envKeyLocalAppData, fakeDrive+"Users\\test\\AppData\\Local")
+	t.Setenv(envKeyProgramData, fakeDrive+"ProgramData")
+	t.Setenv(envKeyProgramFiles, fakeDrive+"ProgramFiles")
+
+	fakeAppName := "test-publisher-windows-app"
+	fakeAppPublisher := "test-publisher"
+	plat, err := NewPlatform(fakeAppPublisher, fakeAppName, "windows")
+
+	require.NoError(t, err)
+	require.NotNil(t, plat)
+
+	windows, ok := plat.(*PlatformWindows)
+	require.True(t, ok)
+	require.NotNil(t, windows)
+
+	// user scoped
+	configDir := windows.UserAppConfigDirectory()
+	configDir = convertToWindowsPath(configDir)
+	assert.True(t, strings.HasSuffix(configDir, fakeAppName))
+	assert.True(t, strings.Contains(configDir, fmt.Sprintf("AppData\\Local\\%s", fakeAppPublisher)))
+	assert.True(t, strings.HasPrefix(configDir, fakeDrive))
+
+	dataDir := windows.UserAppDataDirectory()
+	dataDir = convertToWindowsPath(dataDir)
+	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
+	assert.True(t, strings.Contains(dataDir, fmt.Sprintf("AppData\\Local\\%s", fakeAppPublisher)))
+	assert.True(t, strings.HasPrefix(dataDir, fakeDrive))
+
+	// system scoped
+	configDir = windows.SystemAppConfigDirectory()
+	configDir = convertToWindowsPath(configDir)
+	assert.True(t, strings.HasSuffix(configDir, fakeAppName))
+	assert.Equal(t, fmt.Sprintf("%sProgramFiles\\%s\\%s", fakeDrive, fakeAppPublisher, fakeAppName), configDir)
+
+	dataDir = windows.SystemAppDataDirectory()
+	dataDir = convertToWindowsPath(dataDir)
+	assert.True(t, strings.HasSuffix(dataDir, fakeAppName))
+	assert.Equal(t, fmt.Sprintf("%sProgramData\\%s\\%s", fakeDrive, fakeAppPublisher, fakeAppName), dataDir)
 }

--- a/pkg/platform/windows.go
+++ b/pkg/platform/windows.go
@@ -10,6 +10,7 @@ import (
 type PlatformWindows struct {
 	username         string
 	serviceNamespace string
+	servicePublisher string
 	userHomeDir      string
 	programFiles     string
 	programData      string
@@ -23,7 +24,7 @@ const (
 	envKeyUsername     = "USERNAME"
 )
 
-func NewPlatformWindows(serviceNamespace string) (*PlatformWindows, error) {
+func NewPlatformWindows(servicePublisher, serviceNamespace string) (*PlatformWindows, error) {
 	// On Windows, use user.Current() if available, else fallback to environment variable
 	usr, err := user.Current()
 	if err != nil {
@@ -55,6 +56,7 @@ func NewPlatformWindows(serviceNamespace string) (*PlatformWindows, error) {
 	return &PlatformWindows{
 		username:         usr.Username,
 		serviceNamespace: serviceNamespace,
+		servicePublisher: servicePublisher,
 		userHomeDir:      usrHomeDir,
 		programFiles:     programFiles,
 		programData:      programData,

--- a/pkg/platform/windows.go
+++ b/pkg/platform/windows.go
@@ -74,26 +74,46 @@ func (p PlatformWindows) UserHomeDir() string {
 	return p.userHomeDir
 }
 
-// UserAppDataDirectory returns the namespaced user-level data directory for windows.
-// i.e. %LocalAppData%\<serviceNamespace>
+// UserAppDataDirectory returns the namespaced user-level data directory for Windows.
+// %LocalAppData%\<servicePublisher>\<serviceNamespace>
+// %LocalAppData%\<serviceNamespace> (if no publisher)
 func (p PlatformWindows) UserAppDataDirectory() string {
-	return filepath.Join(p.localAppData, p.serviceNamespace)
+	path := p.localAppData
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }
 
-// UserAppConfigDirectory returns the namespaced user-level config directory for windows.
-// i.e. %LocalAppData%\<serviceNamespace>
+// UserAppConfigDirectory returns the namespaced user-level config directory for Windows.
+// %LocalAppData%\<servicePublisher>\<serviceNamespace>
+// %LocalAppData%\<serviceNamespace> (if no publisher)
 func (p PlatformWindows) UserAppConfigDirectory() string {
-	return filepath.Join(p.localAppData, p.serviceNamespace)
+	path := p.localAppData
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }
 
-// SystemAppDataDirectory returns the namespaced system-level data directory for windows.
-// %ProgramData%\<serviceNamespace>
+// SystemAppDataDirectory returns the namespaced system-level data directory for Windows.
+// %ProgramData%\<servicePublisher>\<serviceNamespace>
+// %ProgramData%\<serviceNamespace> (if no publisher)
 func (p PlatformWindows) SystemAppDataDirectory() string {
-	return filepath.Join(p.programData, p.serviceNamespace)
+	path := p.programData
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }
 
-// SystemAppConfigDirectory returns the namespaced system-level config directory for windows.
-// %ProgramFiles%\<serviceNamespace>
+// SystemAppConfigDirectory returns the namespaced system-level config directory for Windows.
+// %ProgramFiles%\<servicePublisher>\<serviceNamespace>
+// %ProgramFiles%\<serviceNamespace> (if no publisher)
 func (p PlatformWindows) SystemAppConfigDirectory() string {
-	return filepath.Join(p.programFiles, p.serviceNamespace)
+	path := p.programFiles
+	if p.servicePublisher != "" {
+		path = filepath.Join(path, p.servicePublisher)
+	}
+	return filepath.Join(path, p.serviceNamespace)
 }


### PR DESCRIPTION
1. Adds support for optional `service publisher` within the user/system paths as a parent directory of the `service namespace`
2. Updates Linux `SystemAppData` store to `/usr/local` instead of `/var/lib`